### PR TITLE
Allow use of GIT_TOKEN_FILE variable

### DIFF
--- a/.src/redeploy.sh
+++ b/.src/redeploy.sh
@@ -160,9 +160,20 @@ execute_custom_command() {
 
 # Function to write environment variables to a .env file
 write_env_file() {
+  token=$GIT_TOKEN
+
+  if [ -n "$GIT_TOKEN_FILE" ]; then
+    echo_info "GIT_TOKEN_FILE variable found - token will be read from $GIT_TOKEN_FILE"
+    if [ -e $GIT_TOKEN_FILE ]; then
+      token=$(cat $GIT_TOKEN_FILE)
+    else
+      echo_error "Could not read from file"
+    fi
+  fi
+
   cat <<EOF > /root/setup/.env
 _TEMPDIR=${_TEMPDIR}
-GIT_TOKEN=${GIT_TOKEN}
+GIT_TOKEN=${token}
 REPO=${REPO}
 BRANCH=${BRANCH:-main}
 COMMAND=${COMMAND}

--- a/.src/redeploy.sh
+++ b/.src/redeploy.sh
@@ -220,6 +220,7 @@ write_env_file() {
     fi
   fi
 
+  cat <<EOF >/root/setup/.env
 _TEMPDIR=${_TEMPDIR}
 GIT_TOKEN=${token}
 REPO=${REPO}

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ docker compose up
 | REPO           | Yes      | URL of the Git repository                     | `https://github.com/user/repo` | -                                                |
 | BRANCH         | No       | The branch to use for cloning the site        | `main`                         | main                                             |
 | GIT_TOKEN      | No       | Authentication token for private repositories | `ghp_xxxxxxxxxxxx`             | -                                                |
+| GIT_TOKEN_FILE | No       | File to read GIT_TOKEN from                   | `/run/secrets/github_token`    | -                                                |
 | COMMAND        | No       | Custom build/run command                      | `npm install && npm run dev`   | `hugo server -D --noHTTPCache --disableFastRender` |
 | CHECK_INTERVAL | No       | Interval in seconds to check for updates      | `300`                          | 300                                              |
 


### PR DESCRIPTION
Fixes #3 

I've only implemented the `${var}_FILE` scheme for the `GIT_TOKEN_FILE` variable, but from my limited testing I believe this should work. If the user supplies this, then attempt to read the specified file and use the contents to override `GIT_TOKEN`.

Hope this is an acceptable change, happy to restructure if needed. Thanks. 